### PR TITLE
Fixed PHP Warnings

### DIFF
--- a/classes/cardstream.php
+++ b/classes/cardstream.php
@@ -319,7 +319,7 @@
 				)
 			);
 
-			$form = '<form action="' . '//' . $_SERVER[HTTP_HOST] . $_SERVER[REQUEST_URI] . '&step=2" method="post" id="' . $this->gateway . '_payment_form">';
+			$form = '<form action="' . '//' . $_SERVER['HTTP_HOST'] . $_SERVER['EQUEST_URI'] . '&step=2" method="post" id="' . $this->gateway . '_payment_form">';
 
 
 			foreach ($fields as $key => $value) {
@@ -602,7 +602,7 @@
 
 						$message = __('Payment error: ', 'woothemes') . $response['responseMessage'];
 
-						if (method_exists($woocommerce, add_error)) {
+						if (method_exists($woocommerce, 'add_error')) {
 							$woocommerce->add_error($message);
 						} else {
 							wc_add_notice($message, $notice_type = 'error');


### PR DESCRIPTION
- PHP Warning:  Use of undefined constant HTTP_HOST - assumed 'HTTP_HOST' (this will throw an Error in a future version of PHP) on line 322
- PHP Warning:  Use of undefined constant REQUEST_URI - assumed 'REQUEST_URI' (this will throw an Error in a future version of PHP) on line 322
- PHP Warning:  Use of undefined constant add_error - assumed 'add_error' (this will throw an Error in a future version of PHP) on line 605