### PR TITLE
capture_order(): add apply_filters to allow changing $req

### DIFF
--- a/includes/class-wc-payment-network.php
+++ b/includes/class-wc-payment-network.php
@@ -940,6 +940,8 @@ class WC_Payment_Network extends WC_Payment_Gateway
 			'samesite' => 'None'
 		]);
 
+		$req = apply_filters('PaymentNetwork_capture_order', $req, $order);
+
 		return $req;
 	}
 


### PR DESCRIPTION
Use `apply_filters()` to apply user-defined "PaymentNetwork_capture_order" filters to the `$req` array. This allows users to modify the order request attributes before the order is sent.

For example: -

```php
function modify_order_request(array $req, WC_Order $order) {
    $req['orderRef'] = 'custom-order-ref';
    return $req;
}
add_filter('PaymentNetwork_capture_order', 'modify_order_request', 10, 2);
```